### PR TITLE
Remove duplicate XML key

### DIFF
--- a/CodeSystem-onco-core-CodeSystem-OPKomplikationen.xml
+++ b/CodeSystem-onco-core-CodeSystem-OPKomplikationen.xml
@@ -23,7 +23,6 @@
     <description value="OP Komplikationen"/>
     <caseSensitive value="true"/>
     <compositional value="false"/>
-    <content value="complete"/>
     <content value="complete" />
   <count value="79" />
   <concept>


### PR DESCRIPTION
There is a duplicate XML key in this file, which likely also prevented conversion of this resource to JSON on Simplifier. The CS is missing in the 1.6.0 release!