### PR TITLE
Remove typo from VS XML

### DIFF
--- a/ValueSet-onco-core-ValueSet-Projects.xml
+++ b/ValueSet-onco-core-ValueSet-Projects.xml
@@ -22,7 +22,7 @@
         <include>
             <system value="http://dktk.dkfz.de/fhir/onco/core/CodeSystem/Projects"/>
             <concept>
-                <code value="http://dktk.dkfz.de/fhir/sid/exliquid-specimen"/>^^
+                <code value="http://dktk.dkfz.de/fhir/sid/exliquid-specimen"/>
                 <display value="Exliquid"/>
             </concept>
         </include>


### PR DESCRIPTION
This VS is also missing, likely due to a syntactic error